### PR TITLE
feat: add --tags flag to accept additional options on each torrent level

### DIFF
--- a/pkg/core/filebot.go
+++ b/pkg/core/filebot.go
@@ -105,7 +105,7 @@ func DBFromString(db string) (DB, error) {
 	}
 }
 
-func Rename(inputPath string, outputPath string, query string, format string, db DB, action Action, conflict Conflict, language string) (string, error) {
+func Rename(inputPath string, outputPath string, query string, format string, db DB, action Action, conflict Conflict, language string, filter string) (string, error) {
 	// Common arguments for filebot.
 	commonArgs := []string{
 		"-r",
@@ -117,6 +117,9 @@ func Rename(inputPath string, outputPath string, query string, format string, db
 		"--lang", language,
 		"--output", fmt.Sprintf(`"%s"`, outputPath),
 		"-non-strict",
+	}
+	if filter != "" {
+		commonArgs = append(commonArgs, "--filter", filter)
 	}
 
 	var cmd *exec.Cmd
@@ -134,5 +137,6 @@ func Rename(inputPath string, outputPath string, query string, format string, db
 	}
 
 	output, err := cmd.CombinedOutput()
+	log.Printf("Output: %s", output)
 	return string(output), err
 }

--- a/pkg/core/filebot.go
+++ b/pkg/core/filebot.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -122,18 +121,8 @@ func Rename(inputPath string, outputPath string, query string, format string, db
 
 	var cmd *exec.Cmd
 
-	// Windows does not support shell globbing so we expand manually.
 	if runtime.GOOS == "windows" {
-		matches, err := filepath.Glob(inputPath)
-		if err != nil {
-			return "", fmt.Errorf("error expanding glob: %w", err)
-		}
-		if len(matches) == 0 {
-			return "", fmt.Errorf("no files found for pattern %s", inputPath)
-		}
-		// Build the argument slice: first the '-rename', then the expanded file paths, then the common args.
-		args := append([]string{"-rename"}, matches...)
-		args = append(args, commonArgs...)
+		args := append([]string{"-rename", inputPath}, commonArgs...)
 		cmd = exec.Command("filebot", args...)
 		log.Printf("Executing command: filebot %v", args)
 	} else {


### PR DESCRIPTION
- use `--tags "filter:xxx"` to filter episode matching 2e463981a0117107f2f70ee3f5efd0510bdddca3
  - e.g. `--tags "filter:s == 2 && e <= 5"` to get season 2 episode 1 to 5.

> [!NOTE]
> on qbittorent, you can add tag to each torrent to specify their filter for example `filter:s == 2 && e <= 5`.